### PR TITLE
Implemented new BleControlView.

### DIFF
--- a/src/BLEarringController.sln
+++ b/src/BLEarringController.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.12.35527.113 d17.12
+VisualStudioVersion = 17.12.35527.113
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BLEarringController", "BLEarringController/BLEarringController.csproj", "{CEFE6A2D-E11F-43E5-821F-CE7BA46A420E}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BLEarringController", "BLEarringController\BLEarringController.csproj", "{CEFE6A2D-E11F-43E5-821F-CE7BA46A420E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,8 +13,10 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{CEFE6A2D-E11F-43E5-821F-CE7BA46A420E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CEFE6A2D-E11F-43E5-821F-CE7BA46A420E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CEFE6A2D-E11F-43E5-821F-CE7BA46A420E}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{CEFE6A2D-E11F-43E5-821F-CE7BA46A420E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CEFE6A2D-E11F-43E5-821F-CE7BA46A420E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CEFE6A2D-E11F-43E5-821F-CE7BA46A420E}.Release|Any CPU.Deploy.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/BLEarringController/AppShell.xaml
+++ b/src/BLEarringController/AppShell.xaml
@@ -8,7 +8,7 @@
     Title="BLEarringController">
 
     <ShellContent Title="Home"
-                  ContentTemplate="{DataTemplate views:HomePage}"
+                  ContentTemplate="{DataTemplate views:HomePageView}"
                   Route="homepage" />
 
     <ShellContent Title="BLE Control"

--- a/src/BLEarringController/AppShell.xaml
+++ b/src/BLEarringController/AppShell.xaml
@@ -9,10 +9,10 @@
 
     <ShellContent Title="Home"
                   ContentTemplate="{DataTemplate views:HomePage}"
-                  Route="HomePage" />
+                  Route="homepage" />
 
-    <ShellContent Title="BLE Scan"
-                  ContentTemplate="{DataTemplate views:BleScanView}"
-                  Route="BleScanView" />
+    <ShellContent Title="BLE Control"
+                  ContentTemplate="{DataTemplate views:BleControlView}"
+                  Route="blecontrolview"/>
 
 </Shell>

--- a/src/BLEarringController/AppShell.xaml.cs
+++ b/src/BLEarringController/AppShell.xaml.cs
@@ -1,4 +1,6 @@
-﻿namespace BLEarringController
+﻿using BLEarringController.Views;
+
+namespace BLEarringController
 {
     public partial class AppShell : Shell
     {
@@ -7,7 +9,31 @@
         public AppShell()
         {
             InitializeComponent();
+
+            RegisterNavigationRoutes();
         }
+
+        #endregion
+
+        #region Methods
+
+        #region Private Static
+
+        /// <summary>
+        /// Register all relative navigation routes in the app, to allow navigation to views which
+        /// cannot be navigated to from the flyout.
+        /// </summary>
+        /// <remarks>
+        /// This is usually used for modal views, which need to be navigated to from another view.
+        /// </remarks>
+        private static void RegisterNavigationRoutes()
+        {
+            // The BleControlView should be able to navigate to the BleScanView modal to select a
+            // device to control.
+            Routing.RegisterRoute($"{KnownViews.BleControlView}/{KnownModals.BleScanView}", typeof(BleScanView));
+        }
+
+        #endregion
 
         #endregion
     }

--- a/src/BLEarringController/BLEarringController.csproj
+++ b/src/BLEarringController/BLEarringController.csproj
@@ -21,6 +21,8 @@
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!-- Treat warnings as errors to keep this codebase clean! -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- Display name. -->
     <ApplicationTitle>BLEarring Controller</ApplicationTitle>
@@ -85,6 +87,8 @@
     <MauiXaml Update="**\**.xaml">
       <Generator>MSBuild:Compile</Generator>
     </MauiXaml>
+
+    <!-- TODO: Temporary to keep empyty images folder in the .sln -->
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\Images\" />

--- a/src/BLEarringController/BLEarringController.csproj
+++ b/src/BLEarringController/BLEarringController.csproj
@@ -86,5 +86,8 @@
       <Generator>MSBuild:Compile</Generator>
     </MauiXaml>
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\Images\" />
+  </ItemGroup>
 
 </Project>

--- a/src/BLEarringController/BLEarringController.csproj
+++ b/src/BLEarringController/BLEarringController.csproj
@@ -16,6 +16,8 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>BLEarringController</RootNamespace>
     <UseMaui>true</UseMaui>
+    <!-- Enable compiled bindings with source compilation. -->
+    <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/BLEarringController/BLEarringController.csproj
+++ b/src/BLEarringController/BLEarringController.csproj
@@ -20,14 +20,25 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
-    <!-- Display name -->
+    <!-- Display name. -->
     <ApplicationTitle>BLEarring Controller</ApplicationTitle>
 
-    <!-- App Identifier -->
+    <!-- App Identifier. -->
     <ApplicationId>com.blearrings.blearringcontroller</ApplicationId>
 
-    <!-- Versions -->
-    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+    <!-- App Versions. -->
+    <!--
+    This is the app version that can be seen by the end user and stores etc.
+
+    Note that the full semantic versioning specification is not supported, version numbers must be
+    in the format X.Y.Z.
+    -->
+    <ApplicationDisplayVersion>1.0.0</ApplicationDisplayVersion>
+    <!--
+    This version is used to determine whether one version is more recent than another. It must be
+    incremented with every published build and must be an integer. Potentially this could be the
+    build number?
+    -->
     <ApplicationVersion>1</ApplicationVersion>
 
     <!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
@@ -41,23 +52,25 @@
     <DefaultLanguage>en-gb</DefaultLanguage>
   </PropertyGroup>
 
+  <!-- MAUI application resources. -->
   <ItemGroup>
-    <!-- App Icon -->
+    <!-- App Icon. -->
     <MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
 
-    <!-- Splash Screen -->
+    <!-- Splash Screen. -->
     <MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128" />
 
-    <!-- Images -->
+    <!-- Images. -->
     <MauiImage Include="Resources\Images\*" />
 
-    <!-- Custom Fonts -->
+    <!-- Custom Fonts. -->
     <MauiFont Include="Resources\Fonts\*" />
 
-    <!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
+    <!-- Raw Assets (also remove the "Resources\Raw" prefix). -->
     <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
+  <!-- NuGet package references. -->
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Maui" Version="10.0.0" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.21" />

--- a/src/BLEarringController/Ble/BleConstants.cs
+++ b/src/BLEarringController/Ble/BleConstants.cs
@@ -1,0 +1,32 @@
+﻿namespace BLEarringController.Ble
+{
+    /// <summary>
+    /// A class containing constants related to Bluetooth Low Energy.
+    /// </summary>
+    internal static class BleConstants
+    {
+        #region Constants
+
+        #region Internal
+
+        /// <summary>
+        /// The number of bytes in each BLE packet that are used by the ATT protocol. Any MTU size
+        /// will include this overhead.
+        /// </summary>
+        internal const int AttProtocolOverhead = 3;
+
+        /// <summary>
+        /// The absolute maximum MTU size for BLE devices, as defined in the Bluetooth Core
+        /// Specification v5.2, Vol.3, Part F, 3.2.9: "The maximum length of an attribute value
+        /// shall be 512 octets.".
+        /// </summary>
+        /// <remarks>
+        /// Note that this includes the <see cref="AttProtocolOverhead"/>.
+        /// </remarks>
+        internal const int MaxMtuSize = 512;
+
+        #endregion
+
+        #endregion
+    }
+}

--- a/src/BLEarringController/Ble/Services/NordicUart.cs
+++ b/src/BLEarringController/Ble/Services/NordicUart.cs
@@ -1,0 +1,69 @@
+﻿namespace BLEarringController.Ble.Services
+{
+    /// <summary>
+    /// Definitions for the
+    /// <see href="https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/bluetooth/services/nus.html">
+    /// Nordic UART Service</see>.
+    /// </summary>
+    internal static class NordicUart
+    {
+        #region Constants
+
+        #region Internal
+
+        /// <summary>
+        /// The RX characteristic on the <see cref="ServiceId"/>. Data written to the RX
+        /// Characteristic is sent to the UART interface.
+        /// <para>
+        /// Data can be sent to this characteristic with the <c>Write</c> or
+        /// <c>Write Without Response</c> operation.
+        /// </para>
+        /// </summary>
+        internal const string RxCharacteristicId = @"6E400002-B5A3-F393-E0A9-E50E24DCCA9E";
+
+        /// <summary>
+        /// The <see href="https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/bluetooth/services/nus.html#service_uuid">
+        /// vendor-specific UUID for the Nordic Uart Service</see>.
+        /// </summary>
+        internal const string ServiceId = @"6E400001-B5A3-F393-E0A9-E50E24DCCA9E";
+
+        /// <summary>
+        /// The TX characteristic on the <see cref="ServiceId"/>. All data received over UART is
+        /// sent over the TX characteristic as notifications.
+        /// <para>
+        /// Data can only be read from this characteristic using notifications.
+        /// </para>
+        /// </summary>
+        internal const string TxCharacteristicId = @"6E400003-B5A3-F393-E0A9-E50E24DCCA9E";
+
+        #endregion
+
+        #endregion
+
+        #region Fields
+
+        #region Internal Static
+
+        /// <inheritdoc cref="RxCharacteristicId"/>
+        /// <remarks>
+        /// This reflects the <see cref="RxCharacteristicId"/>, but as a <see cref="Guid"/>.
+        /// </remarks>
+        internal static Guid RxCharacteristicGuid = new(RxCharacteristicId);
+
+        /// <inheritdoc cref="ServiceId"/>
+        /// <remarks>
+        /// This reflects the <see cref="ServiceId"/>, but as a <see cref="Guid"/>.
+        /// </remarks>
+        internal static Guid ServiceGuid = new(ServiceId);
+
+        /// <inheritdoc cref="TxCharacteristicId"/>
+        /// <remarks>
+        /// This reflects the <see cref="TxCharacteristicId"/>, but as a <see cref="Guid"/>.
+        /// </remarks>
+        internal static Guid TxCharacteristicGuid = new(TxCharacteristicId);
+
+        #endregion
+
+        #endregion
+    }
+}

--- a/src/BLEarringController/Controls/FixedAspectCard.xaml
+++ b/src/BLEarringController/Controls/FixedAspectCard.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:BLEarringController.Controls"
              x:Class="BLEarringController.Controls.FixedAspectCard">
 
     <!--
@@ -8,7 +9,7 @@
     content from other XAML files, and not interfere with the bindings of the consumer.
     -->
     <ContentView.ControlTemplate>
-        <ControlTemplate>
+        <ControlTemplate x:DataType="controls:FixedAspectCard">
 
             <!--
             The boarder around all card content. This is used to apply the background colour,

--- a/src/BLEarringController/Controls/FixedAspectCard.xaml
+++ b/src/BLEarringController/Controls/FixedAspectCard.xaml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="BLEarringController.Controls.FixedAspectCard">
+
+    <!--
+    Use a ControlTemplate to set the appearance of the card, while still allowing it to accept
+    content from other XAML files, and not interfere with the bindings of the consumer.
+    -->
+    <ContentView.ControlTemplate>
+        <ControlTemplate>
+
+            <!--
+            The boarder around all card content. This is used to apply the background colour,
+            corner radius, and the tap command.
+            -->
+            <Border BackgroundColor="{TemplateBinding CardBackgroundColor}"
+                    StrokeThickness="0">
+
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="{TemplateBinding CornerRadius}" />
+                </Border.StrokeShape>
+
+                <Border.GestureRecognizers>
+                    <TapGestureRecognizer Command="{TemplateBinding CardTappedCommand}" />
+                </Border.GestureRecognizers>
+
+                <!--
+                ContentPresenter to display the content property of the control when used in XAML.
+                This is displayed within the card's styling applied by the ControlTemplate.
+                -->
+                <ContentPresenter />
+
+            </Border>
+
+        </ControlTemplate>
+    </ContentView.ControlTemplate>
+
+</ContentView>

--- a/src/BLEarringController/Controls/FixedAspectCard.xaml.cs
+++ b/src/BLEarringController/Controls/FixedAspectCard.xaml.cs
@@ -206,7 +206,7 @@ namespace BLEarringController.Controls
             }
 
             // The AspectRatio is valid if it is between MinAspectRatio and MaxAspectRatio.
-            return aspectRatio is > MinAspectRatio and < MaxAspectRatio;
+            return aspectRatio is >= MinAspectRatio and <= MaxAspectRatio;
         }
 
         #endregion

--- a/src/BLEarringController/Controls/FixedAspectCard.xaml.cs
+++ b/src/BLEarringController/Controls/FixedAspectCard.xaml.cs
@@ -1,0 +1,216 @@
+namespace BLEarringController.Controls
+{
+    /// <summary>
+    /// A custom control to create a "card" with a fixed aspect ratio to place contents in. The
+    /// card will always take the full width of the parent container, and will adjust its height to
+    /// display with the correct aspect ratio. Note that the height will still be constrained by
+    /// the size of the parent container, so the aspect ratio will not be maintained if the parent
+    /// container does not have enough space available.
+    /// <para>
+    /// The corner radius and background colour of the card are also customisable.
+    /// </para>
+    /// The card can have a <see cref="Command"/> supplied, which will be executed when any area on
+    /// the card is tapped by the user.
+    /// </summary>
+    /// <remarks>
+    /// The aspect ratio defaults to 16:9. It has a minimum value of 1:1, and a maximum value of
+    /// 3:1.
+    /// </remarks>
+    public partial class FixedAspectCard : ContentView
+    {
+        #region Constants
+
+        #region Private
+
+        /// <summary>
+        /// The default aspect ratio is 16:9.
+        /// </summary>
+        private const double DefaultAspectRatio = 16d / 9d;
+
+        /// <summary>
+        /// The maximum aspect ratio is 3:1.
+        /// </summary>
+        private const double MaxAspectRatio = 3;
+
+        /// <summary>
+        /// The minimum aspect ratio is 1:1.
+        /// </summary>
+        private const double MinAspectRatio = 1;
+
+        /// <summary>
+        /// By default, the card is transparent.
+        /// </summary>
+        private static readonly Color s_defaultCardBackgroundColor = Colors.Transparent;
+
+        /// <summary>
+        /// The default corner radius for the card.
+        /// </summary>
+        private static readonly CornerRadius s_defaultCornerRadius = new(20);
+
+        #endregion
+
+        #region Public
+
+        /// <summary>
+        /// The <see cref="BindableProperty"/> for the <see cref="CardBackgroundColor"/>.
+        /// </summary>
+        public static readonly BindableProperty CardBackgroundColorProperty =
+            BindableProperty.Create(nameof(CardBackgroundColor), typeof(Color), typeof(FixedAspectCard), s_defaultCardBackgroundColor);
+
+        /// <summary>
+        /// The <see cref="BindableProperty"/> for the <see cref="CornerRadius"/>.
+        /// </summary>
+        public static readonly BindableProperty CornerRadiusProperty =
+            BindableProperty.Create(nameof(CornerRadius), typeof(CornerRadius), typeof(FixedAspectCard), s_defaultCornerRadius);
+
+        /// <summary>
+        /// The <see cref="BindableProperty"/> for the <see cref="AspectRatio"/>.
+        /// </summary>
+        public static readonly BindableProperty AspectRatioProperty =
+            BindableProperty.Create(nameof(AspectRatio), typeof(double), typeof(FixedAspectCard), DefaultAspectRatio, BindingMode.Default, ValidateAspectRatio, OnAspectRatioChanged);
+
+
+        /// <summary>
+        /// The <see cref="BindableProperty"/> for the <see cref="CardTappedCommand"/>.
+        /// </summary>
+        public static readonly BindableProperty CardTappedCommandProperty =
+            BindableProperty.Create(nameof(CardTappedCommand), typeof(Command), typeof(FixedAspectCard));
+
+        #endregion
+
+        #endregion
+
+        #region Construction
+
+        public FixedAspectCard()
+        {
+            InitializeComponent();
+        }
+
+        #endregion
+
+        #region Properties
+
+        #region Public
+
+        /// <summary>
+        /// The desired aspect ratio for the card. The aspect ratio is represented by a
+        /// <see cref="double"/> which is calculated by dividing the width by the height of the
+        /// desired ratio. For example, a ratio of <c>16:9</c> would be set using the
+        /// <see cref="double"/> <c>1.7777...8</c>.
+        /// </summary>
+        public double AspectRatio
+        {
+            get => (double)GetValue(AspectRatioProperty);
+            set => SetValue(AspectRatioProperty, value);
+        }
+
+        /// <summary>
+        /// The background <see cref="Color"/> for the card.
+        /// </summary>
+        public Color CardBackgroundColor
+        {
+            get => (Color)GetValue(CardBackgroundColorProperty);
+            set => SetValue(CardBackgroundColorProperty, value);
+        }
+
+        /// <summary>
+        /// The <see cref="Command"/> that will be executed when anywhere on the card is tapped.
+        /// </summary>
+        public Command? CardTappedCommand
+        {
+            get => (Command)GetValue(CardTappedCommandProperty);
+            set => SetValue(CardTappedCommandProperty, value);
+        }
+
+        /// <summary>
+        /// The <see cref="CornerRadius"/> for the card.
+        /// </summary>
+        public CornerRadius CornerRadius
+        {
+            get => (CornerRadius)GetValue(CornerRadiusProperty);
+            set => SetValue(CornerRadiusProperty, value);
+        }
+
+        #endregion
+
+        #endregion
+
+        #region Methods
+
+        #region Protected
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// This override attempts to maintain the <see cref="AspectRatio"/> of the card during
+        /// each measure pass. However, this does conform to the height constraint so the aspect
+        /// ratio may not be maintained if the parent container is not large enough.
+        /// </remarks>
+        protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
+        {
+            // Calculate the desired height to maintain the aspect ratio, based on the maximum
+            // available width.
+            var desiredHeight = widthConstraint / AspectRatio;
+
+            // Constrain the height value to the height of the parent container.
+            desiredHeight = Math.Min(desiredHeight, heightConstraint);
+
+            // Return the desired size for the control, constrained by the width and height of the
+            // parent container.
+            return new Size(widthConstraint, desiredHeight);
+        }
+
+        #endregion
+
+        #region Private Static
+
+        /// <summary>
+        /// A delegate that is called when the <see cref="AspectRatioProperty"/> is changed. This
+        /// invokes <see cref="VisualElement.InvalidateMeasure"/> on the
+        /// <see cref="BindableObject"/> if it is a <see cref="FixedAspectCard"/>, so that the
+        /// <see cref="MeasureOverride"/> is called to re-calculate the size of the card.
+        /// </summary>
+        /// <param name="bindable">
+        /// The object that owns the <see cref="BindableProperty"/> that changed.
+        /// </param>
+        /// <param name="oldValue">The old <see cref="AspectRatio"/> value.</param>
+        /// <param name="newValue">The new <see cref="AspectRatio"/> value.</param>
+        private static void OnAspectRatioChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            // Ensure the BindableObject is a FixedAspectCard.
+            if (bindable is FixedAspectCard card)
+            {
+                // Call InvalidateMeasure() on the FixedAspectCard, to cause a measure pass so that
+                // the new aspect ratio is reflected by the card.
+                card.InvalidateMeasure();
+            }
+        }
+
+        /// <summary>
+        /// A delegate that is called to validate values of the <see cref="AspectRatioProperty"/>.
+        /// This ensures that the <see cref="AspectRatio"/> can only be set to values between
+        /// <see cref="MinAspectRatio"/> and <see cref="MaxAspectRatio"/>.
+        /// </summary>
+        /// <param name="bindable">
+        /// The object that owns the <see cref="BindableProperty"/> that the value is being
+        /// validated for.
+        /// </param>
+        /// <param name="value">The value to validate.</param>
+        /// <returns></returns>
+        private static bool ValidateAspectRatio(BindableObject bindable, object value)
+        {
+            // The AspectRatio must be a double. Any other values are invalid.
+            if (value is not double aspectRatio)
+            {
+                return false;
+            }
+
+            // The AspectRatio is valid if it is between MinAspectRatio and MaxAspectRatio.
+            return aspectRatio is > MinAspectRatio and < MaxAspectRatio;
+        }
+
+        #endregion
+
+        #endregion
+    }
+}

--- a/src/BLEarringController/Converters/ComplementaryColourConverter.cs
+++ b/src/BLEarringController/Converters/ComplementaryColourConverter.cs
@@ -1,0 +1,75 @@
+﻿using System.Globalization;
+
+namespace BLEarringController.Converters
+{
+    /// <summary>
+    /// <see cref="IValueConverter"/> to find the complement of a <see cref="Color"/>.
+    /// </summary>
+    internal class ComplementaryColourConverter : IValueConverter
+    {
+        #region Constants
+
+        #region Private
+
+        /// <summary>
+        /// The maximum value for each <see cref="Color"/> channel, when read from the
+        /// <see cref="Color.Red"/>, <see cref="Color.Green"/> and <see cref="Color.Blue"/> values.
+        /// </summary>
+        private const float MaxChannelValue = 1f;
+
+        #endregion
+
+        #endregion
+
+        #region Methods
+
+        #region Public
+
+        /// <summary>
+        /// Convert a <see cref="Color"/> to its complement. Note that this retains the
+        /// <see cref="Color.Alpha"/> channel value.
+        /// </summary>
+        /// <param name="value">The <see cref="Color"/> to convert.</param>
+        /// <param name="targetType">Ignored.</param>
+        /// <param name="parameter">Ignored.</param>
+        /// <param name="culture">Ignored.</param>
+        /// <returns>
+        /// The complementary <see cref="Color"/> to the input value, or <c>null</c> if the input
+        /// value was not a <see cref="Color"/>.
+        /// </returns>
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is not Color backgroundColour)
+            {
+                // If the input value is not a colour, return null.
+                return null;
+            }
+
+            // Convert the colour to its complement by inverting the values in the red, green and
+            // blue channels. The alpha channel value is not changed.
+            //
+            // Note that the channel values are returned as floats between 0 and 1.
+            return Color.FromRgba(
+                MaxChannelValue - backgroundColour.Red,
+                MaxChannelValue - backgroundColour.Green,
+                MaxChannelValue - backgroundColour.Blue,
+                backgroundColour.Alpha);
+        }
+
+        /// <inheritdoc cref="Convert"/>.
+        /// <remarks>
+        /// The process of finding a complementary <see cref="Color"/> is reversible, so this just
+        /// wraps the <see cref="Convert"/> method. <see cref="Convert"/> should be called directly
+        /// if possible.
+        /// </remarks>
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            // Just call the Convert() method, as this is a reversible process.
+            return Convert(value, targetType, parameter, culture);
+        }
+
+        #endregion
+
+        #endregion
+    }
+}

--- a/src/BLEarringController/Converters/ContrastingTextColourConverter.cs
+++ b/src/BLEarringController/Converters/ContrastingTextColourConverter.cs
@@ -1,0 +1,108 @@
+﻿using System.Globalization;
+
+namespace BLEarringController.Converters
+{
+    /// <summary>
+    /// <see cref="IValueConverter"/> to convert a background <see cref="Color"/> to a standard
+    /// text <see cref="Color"/> that has the best contrast against the background.
+    /// </summary>
+    public class ContrastingTextColourConverter : IValueConverter
+    {
+        #region Constants
+
+        #region Private
+
+        /// <summary>
+        /// The luma coefficient for blue for formats following the
+        /// <see href="https://en.wikipedia.org/wiki/Rec._709">ITU-R Recommendation 709</see>.
+        /// </summary>
+        private const double BlueLumaCoefficient = 0.0722;
+
+        /// <summary>
+        /// The luma coefficient for green for formats following the
+        /// <see href="https://en.wikipedia.org/wiki/Rec._709">ITU-R Recommendation 709</see>.
+        /// </summary>
+        private const double GreenLumaCoefficient = 0.7152;
+
+        /// <summary>
+        /// The value representing the midpoint of the luma range. Values greater than this are
+        /// considered "bright" and values lower than this are considered "dark".
+        /// </summary>
+        private const double LumaMidpoint = 0.5;
+
+        /// <summary>
+        /// The luma coefficient for red for formats following the
+        /// <see href="https://en.wikipedia.org/wiki/Rec._709">ITU-R Recommendation 709</see>.
+        /// </summary>
+        private const double RedLumaCoefficient = 0.2126;
+
+        #endregion
+
+        #endregion
+
+        #region Methods
+
+        #region Public
+
+        /// <summary>
+        /// Convert a background <see cref="Color"/> to a text <see cref="Color"/> that should
+        /// contrast the background. Note that this only uses <see cref="Colors.Black"/> and
+        /// <see cref="Colors.White"/>, based on the luma of the background.
+        /// </summary>
+        /// <param name="value">
+        /// The background <see cref="Color"/> that the text is displayed against.
+        /// </param>
+        /// <param name="targetType">Ignored.</param>
+        /// <param name="parameter">Ignored.</param>
+        /// <param name="culture">Ignored.</param>
+        /// <returns>
+        /// Either <see cref="Colors.Black"/> or <see cref="Colors.White"/>, depending on which has
+        /// the best contrast against the background.
+        /// </returns>
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is not Color backgroundColour)
+            {
+                // Return null if the provided object was not a colour.
+                return null;
+            }
+
+            // Calculate the "luma" of the background colour, assuming the colour is represented
+            // using Rec. 709 colour representation.
+            //
+            // Note that the red, green and blue values are returned as floats between 0 and 1, so
+            // the "luma" value will also be between 0 and 1.
+            var luma = backgroundColour.Red * RedLumaCoefficient
+                       + backgroundColour.Green * GreenLumaCoefficient
+                       + backgroundColour.Blue * BlueLumaCoefficient;
+
+            // Check the luma value against the midpoint of the luma range. If it is "lighter"
+            // (i.e. greater) than the midpoint, the text should be dark. If it is "darker" (i.e.
+            // less than) the midpoint, the text should be light.
+            return luma > LumaMidpoint ? Colors.Black : Colors.White;
+
+        }
+
+        /// <summary>
+        /// This method is not implemented, it is not possible to convert back to the background
+        /// colour.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="targetType"></param>
+        /// <param name="parameter"></param>
+        /// <param name="culture"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException">
+        /// This method will throw a <see cref="NotImplementedException"/>, as it is not
+        /// implemented.
+        /// </exception>
+        public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #endregion
+    }
+}

--- a/src/BLEarringController/Converters/ContrastingTextColourConverter.cs
+++ b/src/BLEarringController/Converters/ContrastingTextColourConverter.cs
@@ -58,6 +58,9 @@ namespace BLEarringController.Converters
         /// <returns>
         /// Either <see cref="Colors.Black"/> or <see cref="Colors.White"/>, depending on which has
         /// the best contrast against the background.
+        /// <para>
+        /// Note that <c>null</c> is returned if the input value is not a <see cref="Color"/>.
+        /// </para>
         /// </returns>
         public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         {

--- a/src/BLEarringController/Platforms/Windows/app.manifest
+++ b/src/BLEarringController/Platforms/Windows/app.manifest
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="BLEarringController.WinUI.app"/>
+  <!-- Set version to 0.0.0.0 so it follows the ApplicationDisplayVersion in the .csproj. -->
+  <assemblyIdentity version="0.0.0.0" name="BLEarringController.WinUI.app"/>
 
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>

--- a/src/BLEarringController/ViewModels/BleControlViewModel.cs
+++ b/src/BLEarringController/ViewModels/BleControlViewModel.cs
@@ -1,0 +1,338 @@
+﻿using System.Diagnostics;
+using System.Text;
+using BLEarringController.Ble;
+using BLEarringController.Ble.Services;
+using BLEarringController.Views;
+using Plugin.BLE;
+using Plugin.BLE.Abstractions;
+using Plugin.BLE.Abstractions.Contracts;
+
+namespace BLEarringController.ViewModels
+{
+    public sealed class BleControlViewModel : ViewModelBase
+    {
+        #region Fields
+
+        #region Private
+
+        /// <summary>
+        /// The current <see cref="IAdapter"/> used by the current
+        /// <see cref="_bleImplementation"/>.
+        /// </summary>
+        private readonly IAdapter _bleAdapter;
+
+        /// <summary>
+        /// The current <see cref="IBluetoothLE"/> implementation on the device.
+        /// </summary>
+        private readonly IBluetoothLE _bleImplementation;
+
+        /// <summary>
+        /// Backing variable for <see cref="BlueSliderValue"/>.
+        /// </summary>
+        private int _blueSliderValue;
+
+        /// <summary>
+        /// backing variable for <see cref="CardAspectRatio"/>.
+        /// </summary>
+        private double _cardAspectRatio;
+
+        /// <summary>
+        /// Backing variable for <see cref="GreenSliderValue"/>.
+        /// </summary>
+        private int _greenSliderValue;
+
+        /// <summary>
+        /// Backing variable for <see cref="RedSliderValue"/>.
+        /// </summary>
+        private int _redSliderValue;
+
+        /// <summary>
+        /// Backing variable for <see cref="SelectedBleDevice"/>.
+        /// </summary>
+        private IDevice? _selectedBleDevice;
+
+        #endregion
+
+        #endregion
+
+        #region Construction
+
+        public BleControlViewModel()
+        {
+            // Convenient variables to access the current IBluetoothLE and IAdapter objects.
+            _bleImplementation = CrossBluetoothLE.Current;
+            _bleAdapter = _bleImplementation.Adapter;
+
+            // Create commands to invoke methods when UI buttons are clicked.
+            SelectDeviceCommand = new Command(SelectDeviceCommandTask);
+            SendColourCommand = new Command(SendColourCommandTask);
+        }
+
+        #endregion
+
+        #region Properties
+
+        #region Public
+
+        /// <summary>
+        /// Text to display on the device information card when a property of the BLE device is
+        /// <c>null</c>.
+        /// </summary>
+        public string BleDeviceNullFallback => "Null";
+
+        /// <summary>
+        /// The value selected on the blue slider.
+        /// </summary>
+        public int BlueSliderValue
+        {
+            get => _blueSliderValue;
+            set
+            {
+                if (_blueSliderValue != value)
+                {
+                    _blueSliderValue = value;
+                    NotifyPropertyChanged();
+
+                    // Raise PropertyChanged notification for derived properties.
+                    NotifyPropertyChanged(nameof(BlueThumbColor));
+                    NotifyPropertyChanged(nameof(SelectedColor));
+                }
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="Color"/> to display on the thumb of the blue slider. This represents the
+        /// intensity of the current <see cref="BlueSliderValue"/>.
+        /// </summary>
+        public Color BlueThumbColor => Color.FromRgb(0, 0, _blueSliderValue);
+
+        // TODO: Temporary aspect ratio slider value for testing.
+        public double CardAspectRatio
+        {
+            get => _cardAspectRatio;
+            set
+            {
+                if (Math.Abs(_cardAspectRatio - value) > 0.01)
+                {
+                    _cardAspectRatio = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        /// The value selected on the green slider.
+        /// </summary>
+        public int GreenSliderValue
+        {
+            get => _greenSliderValue;
+            set
+            {
+                if (_greenSliderValue != value)
+                {
+                    _greenSliderValue = value;
+                    NotifyPropertyChanged();
+
+                    // Raise PropertyChanged notification for derived properties.
+                    NotifyPropertyChanged(nameof(GreenThumbColor));
+                    NotifyPropertyChanged(nameof(SelectedColor));
+                }
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="Color"/> to display on the thumb of the green slider. This represents
+        /// the intensity of the current <see cref="GreenSliderValue"/>.
+        /// </summary>
+        public Color GreenThumbColor => Color.FromRgb(0, _greenSliderValue, 0);
+
+        /// <summary>
+        /// Text to display in the "Name" field when a device is not selected.
+        /// </summary>
+        public string NoBleDeviceName => "No BLE device selected.";
+
+        /// <summary>
+        /// Text to display over the top of the card before a device is selected.
+        /// </summary>
+        public string NoDeviceSelectedCardText => "No device selected. Tap this card to select a device.";
+
+        /// <summary>
+        /// The value selected on the red slider.
+        /// </summary>
+        public int RedSliderValue
+        {
+            get => _redSliderValue;
+            set
+            {
+                if (_redSliderValue != value)
+                {
+                    _redSliderValue = value;
+                    NotifyPropertyChanged();
+
+                    // Raise PropertyChanged notification for derived properties.
+                    NotifyPropertyChanged(nameof(RedThumbColor));
+                    NotifyPropertyChanged(nameof(SelectedColor));
+                }
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="Color"/> to display on the thumb of the red slider. This represents the
+        /// intensity of the current <see cref="BlueSliderValue"/>.
+        /// </summary>
+        public Color RedThumbColor => Color.FromRgb(_redSliderValue, 0, 0);
+
+        /// <summary>
+        /// The <see cref="Command"/> that will wrap the <see cref="SelectDeviceCommandTask"/>.
+        /// </summary>
+        public Command SelectDeviceCommand { get; }
+
+        /// <summary>
+        /// The currently selected <see cref="IDevice"/>.
+        /// </summary>
+        /// <remarks>
+        /// This will be <c>null</c> before a device is selected.
+        /// </remarks>
+        public IDevice? SelectedBleDevice
+        {
+            get => _selectedBleDevice;
+            set
+            {
+                // To check if a new value is the same device, compare the MAC addresses.
+                if (_selectedBleDevice?.Id != value?.Id)
+                {
+                    _selectedBleDevice = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="Color"/> represented by the current <see cref="RedSliderValue"/>,
+        /// <see cref="GreenSliderValue"/>, and <see cref="BlueSliderValue"/> selections.
+        /// </summary>
+        public Color SelectedColor => Color.FromRgb(_redSliderValue, _greenSliderValue, _blueSliderValue);
+
+        /// <summary>
+        /// Text to display on the button that sends the <see cref="SelectedColor"/> to the
+        /// <see cref="SelectedBleDevice"/>.
+        /// </summary>
+        public string SendColourButtonText => "Send colour to device";
+
+        /// <summary>
+        /// The <see cref="Command"/> that will wrap the <see cref="SendColourCommandTask"/>.
+        /// </summary>
+        public Command SendColourCommand { get; }
+
+        #endregion
+
+        #endregion
+
+        #region Methods
+
+        #region Private
+
+        /// <summary>
+        /// Send the <see cref="SelectedColor"/> to the <see cref="SelectedBleDevice"/>.
+        /// </summary>
+        private async void SendColourCommandTask()
+        {
+            // Wrap the entire method in a try-catch to prevent exceptions crashing the process,
+            // since this is an async void.
+            try
+            {
+                // If no device is selected, colour cannot be sent so just return.
+                if (SelectedBleDevice == null)
+                {
+                    // TODO: display popup to user.
+                    return;
+                }
+                // Ensure device is connected before colour can be sent.
+                await _bleAdapter.ConnectToDeviceAsync(SelectedBleDevice);
+                if (SelectedBleDevice.State != DeviceState.Connected)
+                {
+                    // TODO: display popup to user.
+                    return;
+                }
+
+                // Get the Nordic UART Service and RX characteristic from the device to send the
+                // colour to.
+                if (await SelectedBleDevice.GetServiceAsync(NordicUart.ServiceGuid) is { } uartService
+                    && await uartService.GetCharacteristicAsync(NordicUart.RxCharacteristicGuid) is { CanWrite: true } rxCharacteristic)
+                {
+                    // TODO: This is for testing. A proper packet structure needs to be agreed.
+                    // Convert the selected red, green and blue values to an arbitrary string to
+                    // send to the device.
+                    var payloadBytes = Encoding.UTF8.GetBytes($"{RedSliderValue},{GreenSliderValue},{BlueSliderValue}");
+
+                    // TODO: Only negotiate the MTU size once per connection.
+                    // Try and negotiate the largest MTU size possible.
+                    var currentMtu = await SelectedBleDevice.RequestMtuAsync(BleConstants.MaxMtuSize);
+
+                    // In debug, ensure the packet can be transmitted with the given MTU.
+                    Debug.Assert(payloadBytes.Length <= currentMtu - BleConstants.AttProtocolOverhead);
+
+                    // Attempt to write the payload to the RX characteristic.
+                    var writeResult = await rxCharacteristic.WriteAsync(payloadBytes);
+
+                    if (writeResult != 0)
+                    {
+                        // TODO: Display popup.
+                        // TODO: Switch result to display error messages?
+                        Debug.Assert(false);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // Catch all exceptions here and break in debug, as it is unexpected.
+                Debug.Assert(false, ex.Message);
+            }
+        }
+
+        #endregion
+
+        #region Public
+
+        /// <inheritdoc />
+        public override void ApplyQueryAttributes(IDictionary<string, object> query)
+        {
+            // Apply any supported NavigationQueryKeys after navigation.
+            if (query.TryGetValue(NavigationQueryKeys.SelectedBleDeviceKey, out var selection)
+                && selection is IDevice selectedBleDevice)
+            {
+                // If the query contains an IDevice, apply it to the ViewModel.
+                SelectedBleDevice = selectedBleDevice;
+            }
+        }
+
+        #endregion
+
+        #region Private Static
+
+        /// <summary>
+        /// Opens the <see cref="KnownModals.BleScanView"/> to allow the user to select a
+        /// <see cref="IDevice"/> from a BLE scan.
+        /// </summary>
+        private static async void SelectDeviceCommandTask()
+        {
+            // Wrap the entire method in a try-catch to prevent exceptions crashing the process,
+            // since this is an async void.
+            try
+            {
+                // Open the BleScanView modal to allow the user to select a BLE device.
+                await Shell.Current.GoToAsync(KnownModals.BleScanView);
+            }
+            catch (Exception ex)
+            {
+                // TODO: Alert user!
+                // In Debug, always break here as this is unexpected!
+                Debug.Assert(false, ex.Message);
+            }
+        }
+
+        #endregion
+
+        #endregion
+    }
+}

--- a/src/BLEarringController/ViewModels/ViewModelBase.cs
+++ b/src/BLEarringController/ViewModels/ViewModelBase.cs
@@ -6,7 +6,7 @@ namespace BLEarringController.ViewModels
     /// <summary>
     /// Base class for all view models.
     /// </summary>
-    public abstract class ViewModelBase : INotifyPropertyChanged
+    public abstract class ViewModelBase : INotifyPropertyChanged, IQueryAttributable
     {
         #region Events
 
@@ -29,6 +29,15 @@ namespace BLEarringController.ViewModels
         protected void NotifyPropertyChanged([CallerMemberName] string? propertyName = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        #endregion
+
+        #region Public
+
+        /// <inheritdoc />
+        public virtual void ApplyQueryAttributes(IDictionary<string, object> query)
+        {
         }
 
         #endregion

--- a/src/BLEarringController/Views/BleControlView.xaml
+++ b/src/BLEarringController/Views/BleControlView.xaml
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewModels="using:BLEarringController.ViewModels"
+             xmlns:controls="using:BLEarringController.Controls"
+             xmlns:converters="using:BLEarringController.Converters"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             x:Class="BLEarringController.Views.BleControlView"
+             x:DataType="viewModels:BleControlViewModel"
+             Shell.PresentationMode="ModalAnimated">
+
+    <ContentPage.BindingContext>
+        <!-- TODO: This feels a bit clunky, but for only a couple of views should be fine. -->
+        <viewModels:BleControlViewModel />
+    </ContentPage.BindingContext>
+
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <converters:ContrastingTextColourConverter x:Key="ContrastingTextColourConverter" />
+            <converters:GuidToMacStringConverter x:Key="GuidToMacStringConverter" />
+            <toolkit:IsNullConverter x:Key="IsNullConverter"/>
+            <toolkit:IsNotNullConverter x:Key="IsNotNullConverter"/>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+
+    <Grid Margin="20,10,20,20"
+          RowSpacing="20">
+
+        <Grid.RowDefinitions>
+            <!-- Card showing basic information about the BLE device. -->
+            <RowDefinition Height="Auto" />
+            <!-- Colour picker sliders. -->
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <!-- TODO: Temporary aspect ratio slider. -->
+            <RowDefinition Height="Auto" />
+            <!--
+            Row to take up remaining space on the page, to ensure the button stays at the bottom of
+            the page.
+            -->
+            <RowDefinition Height="*" />
+            <!-- Button to send the colour to the BLE device. -->
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <!-- Fixed aspect ratio card to display information about the BLE device. -->
+        <controls:FixedAspectCard Grid.Row="0"
+                                  CardBackgroundColor="DimGray"
+                                  AspectRatio="{Binding CardAspectRatio}"
+                                  CardTappedCommand="{Binding SelectDeviceCommand}">
+
+            <Grid x:Name="CardContentGrid"
+                  Margin="10"
+                  ColumnSpacing="10">
+
+                <Grid.RowDefinitions>
+                    <!-- Top row used for the start of the image, and the settings icon. -->
+                    <RowDefinition Height="Auto"/>
+                    <!-- Row used for the BLE device name. -->
+                    <RowDefinition Height="Auto"/>
+                    <!-- Row used for the BLE device MAC address. -->
+                    <RowDefinition Height="Auto"/>
+                    <!-- Row used for the BLE device RSSI. -->
+                    <RowDefinition Height="Auto"/>
+                    <!-- Last row used to take up all remaining space. -->
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <Grid.ColumnDefinitions>
+                    <!-- First column is used to display an image of the device. -->
+                    <ColumnDefinition Width="Auto"/>
+                    <!-- Middle column is used to display text properties of the BLE device. -->
+                    <ColumnDefinition Width="*"/>
+                    <!-- Last column is used to display the settings icon. -->
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- TODO: Add image of the device. -->
+                <!--
+                Placeholder for the device image.
+
+                The image will also be used to display the selected colour as a preview. The image
+                will span across all rows.
+                -->
+                <Border Grid.Column="0"
+                        Grid.Row="0"
+                        Grid.RowSpan="{Binding RowDefinitions.Count, Source={x:Reference CardContentGrid}, x:DataType='Grid'}"
+                        BackgroundColor="{Binding SelectedColor}">
+
+                    <Border.StrokeShape>
+                        <RoundRectangle CornerRadius="10"/>
+                    </Border.StrokeShape>
+
+                    <Label Text="Image Placeholder"
+                           HorizontalOptions="Center"
+                           VerticalOptions="Center"
+                           Padding="5"
+                           TextColor="{Binding SelectedColor, Converter={StaticResource ContrastingTextColourConverter}}"/>
+
+                </Border>
+
+                <!-- Label to display the device name. -->
+                <Label Grid.Column="1"
+                       Grid.Row="1"
+                       Text="{Binding SelectedBleDevice.Name,  FallbackValue={Binding NoBleDeviceName}, TargetNullValue={Binding BleDeviceNullFallback}}"
+                       HorizontalOptions="Start"
+                       VerticalOptions="Center" />
+
+                <!-- Label to display the device MAC address. -->
+                <Label Grid.Column="1"
+                       Grid.Row="2"
+                       Text="{Binding SelectedBleDevice.Id, FallbackValue={Binding BleDeviceNullFallback}, Converter={StaticResource GuidToMacStringConverter}}"
+                       HorizontalOptions="Start"
+                       VerticalOptions="Center" />
+
+                <!-- TODO: Update this value as a "live" value. -->
+                <!-- Label to display the RSSI value. -->
+                <Label Grid.Column="1"
+                       Grid.Row="3"
+                       Text="{Binding SelectedBleDevice.Rssi, FallbackValue={Binding BleDeviceNullFallback}}"
+                       HorizontalOptions="Start"
+                       VerticalOptions="Center" />
+
+                <!--
+                Content displayed over the entire card before a device is selected. This hints to
+                the user to click the card and select a device.
+
+                Once a device is selected, it becomes invisible to reveal the information behind
+                it.
+                -->
+                <Border Grid.Column="0"
+                        Grid.Row="0"
+                        Grid.ColumnSpan="{Binding ColumnDefinitions.Count, Source={x:Reference CardContentGrid}, x:DataType='Grid'}"
+                        Grid.RowSpan="{Binding RowDefinitions.Count, Source={x:Reference CardContentGrid}, x:DataType='Grid'}"
+                        IsVisible="{Binding SelectedBleDevice, Converter={StaticResource IsNullConverter}}"
+                        BackgroundColor="DimGray"
+                        StrokeThickness="0">
+
+                    <Label Text="{Binding NoDeviceSelectedCardText}"
+                           HorizontalOptions="Center"
+                           VerticalOptions="Center" />
+
+                </Border>
+
+                <!-- TODO: Add settings icon. -->
+                <!-- Settings icon to hint that clicking the card opens a modal. -->
+                <Border Grid.Column="2"
+                        Grid.Row="0"
+                        HeightRequest="25"
+                        WidthRequest="25"
+                        BackgroundColor="Fuchsia">
+
+                    <Border.StrokeShape>
+                        <!-- Ellipse to make the border round. -->
+                        <Ellipse />
+                    </Border.StrokeShape>
+
+                </Border>
+
+            </Grid>
+
+        </controls:FixedAspectCard>
+
+        <!-- Sliders to allow the user to select a red, green and blue value. -->
+        <Slider Grid.Row="1"
+                Value="{Binding RedSliderValue}"
+                ThumbColor="{Binding RedThumbColor}"
+                Maximum="255"
+                MaximumTrackColor="DarkRed"
+                Minimum="0"
+                MinimumTrackColor="Red" />
+
+        <Slider Grid.Row="2"
+                Value="{Binding GreenSliderValue}"
+                ThumbColor="{Binding GreenThumbColor}"
+                Maximum="255"
+                MaximumTrackColor="DarkGreen"
+                Minimum="0"
+                MinimumTrackColor="Green" />
+
+        <Slider Grid.Row="3"
+                Value="{Binding BlueSliderValue}"
+                ThumbColor="{Binding BlueThumbColor}"
+                Maximum="255"
+                MaximumTrackColor="DarkBlue"
+                Minimum="0"
+                MinimumTrackColor="Blue" />
+
+        <!-- TODO: Temporary slider to adjust card aspect ratio. -->
+        <Slider Grid.Row="4"
+                Value="{Binding CardAspectRatio}"
+                ThumbColor="Fuchsia"
+                Maximum="3"
+                MaximumTrackColor="DeepPink"
+                Minimum="1"
+                MinimumTrackColor="Fuchsia" />
+
+        <!-- TODO: Reduce Grid.Row to 5 when above slider is removed. -->
+        <!--
+        Button to send the selected colour to the BLE device. This is disabled when a device is not
+        selected.
+        -->
+        <Button Grid.Row="6"
+                Text="{Binding SendColourButtonText}"
+                Command="{Binding SendColourCommand}"
+                IsEnabled="{Binding SelectedBleDevice, Converter={StaticResource IsNotNullConverter}}"/>
+    </Grid>
+
+</ContentPage>

--- a/src/BLEarringController/Views/BleControlView.xaml.cs
+++ b/src/BLEarringController/Views/BleControlView.xaml.cs
@@ -1,0 +1,14 @@
+namespace BLEarringController.Views
+{
+    public partial class BleControlView : ContentPage
+    {
+        #region Construction
+
+        public BleControlView()
+        {
+            InitializeComponent();
+        }
+
+        #endregion
+    }
+}

--- a/src/BLEarringController/Views/BleScanView.xaml
+++ b/src/BLEarringController/Views/BleScanView.xaml
@@ -6,7 +6,8 @@
              xmlns:converters="clr-namespace:BLEarringController.Converters"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              x:Class="BLEarringController.Views.BleScanView"
-             x:DataType="viewModels:BleScanViewModel">
+             x:DataType="viewModels:BleScanViewModel"
+             Shell.PresentationMode="ModalAnimated">
 
     <ContentPage.BindingContext>
         <!-- TODO: This feels a bit clunky, but for only a couple of views should be fine. -->
@@ -44,7 +45,10 @@
                Style="{StaticResource SubHeadline}" />
 
         <CollectionView Grid.Row="2"
-                        ItemsSource="{Binding FoundDevices}">
+                        ItemsSource="{Binding FoundDevices}"
+                        SelectionMode="Single"
+                        SelectionChangedCommand="{Binding DeviceSelectedCommand}"
+                        SelectionChangedCommandParameter="{Binding Path=SelectedItem, Source={x:RelativeSource Self}, x:DataType='CollectionView'}">
 
             <!-- Define the DataTemplate used for each discovered IDevice. -->
             <CollectionView.ItemTemplate>
@@ -60,16 +64,17 @@
 
                         <HorizontalStackLayout>
                             <Label Text="MAC: "/>
-                            <Label Text="{Binding Id, Converter={StaticResource GuidMacConverter}}"/>
+                            <Label Text="{Binding Id, Converter={StaticResource GuidMacConverter}, TargetNullValue='Null'}"/>
                         </HorizontalStackLayout>
 
+                        <!-- TODO: Add live updates to this value. -->
                         <HorizontalStackLayout>
                             <Label Text="RSSI: "/>
-                            <Label Text="{Binding Rssi}"/>
+                            <Label Text="{Binding Rssi, TargetNullValue='Null'}"/>
                         </HorizontalStackLayout>
 
                     </VerticalStackLayout>
-                    
+
                 </DataTemplate>
             </CollectionView.ItemTemplate>
 

--- a/src/BLEarringController/Views/HomePage.xaml
+++ b/src/BLEarringController/Views/HomePage.xaml
@@ -4,7 +4,7 @@
              xmlns:viewModels="clr-namespace:BLEarringController.ViewModels"
              x:Class="BLEarringController.Views.HomePage"
              x:DataType="viewModels:HomePageViewModel">
-    
+
     <ContentPage.BindingContext>
         <viewModels:HomePageViewModel />
     </ContentPage.BindingContext>

--- a/src/BLEarringController/Views/HomePageView.xaml
+++ b/src/BLEarringController/Views/HomePageView.xaml
@@ -2,7 +2,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:viewModels="clr-namespace:BLEarringController.ViewModels"
-             x:Class="BLEarringController.Views.HomePage"
+             x:Class="BLEarringController.Views.HomePageView"
              x:DataType="viewModels:HomePageViewModel">
 
     <ContentPage.BindingContext>

--- a/src/BLEarringController/Views/HomePageView.xaml.cs
+++ b/src/BLEarringController/Views/HomePageView.xaml.cs
@@ -1,10 +1,10 @@
 ﻿namespace BLEarringController.Views
 {
-    public partial class HomePage : ContentPage
+    public partial class HomePageView : ContentPage
     {
         #region Construction
 
-        public HomePage()
+        public HomePageView()
         {
             InitializeComponent();
         }

--- a/src/BLEarringController/Views/KnownModals.cs
+++ b/src/BLEarringController/Views/KnownModals.cs
@@ -1,0 +1,26 @@
+﻿using Plugin.BLE.Abstractions.Contracts;
+
+namespace BLEarringController.Views
+{
+    internal static class KnownModals
+    {
+        #region Constants
+
+        #region Internal
+
+        /// <summary>
+        /// A modal that allows scanning for Bluetooth LE devices, and allows the user to select
+        /// one that they would like to connect to.
+        /// </summary>
+        /// <remarks>
+        /// This view will navigate backwards once a device has been selected, and return the
+        /// selected <see cref="IDevice"/> in the <see cref="ShellNavigationQueryParameters"/>
+        /// under the <see cref="NavigationQueryKeys.SelectedBleDeviceKey"/> key.
+        /// </remarks>
+        internal const string BleScanView = @"blescanview";
+
+        #endregion
+
+        #endregion
+    }
+}

--- a/src/BLEarringController/Views/KnownViews.cs
+++ b/src/BLEarringController/Views/KnownViews.cs
@@ -13,6 +13,11 @@ namespace BLEarringController.Views
         /// </summary>
         internal const string BleControlView = @"blecontrolview";
 
+        /// <summary>
+        /// The initial home page for the app.
+        /// </summary>
+        internal const string HomePageView = @"homepageview";
+
         #endregion
 
         #endregion

--- a/src/BLEarringController/Views/KnownViews.cs
+++ b/src/BLEarringController/Views/KnownViews.cs
@@ -1,0 +1,20 @@
+﻿using Plugin.BLE.Abstractions.Contracts;
+
+namespace BLEarringController.Views
+{
+    internal static class KnownViews
+    {
+        #region Constants
+
+        #region Internal
+
+        /// <summary>
+        /// A view that allows the user to control an <see cref="IDevice"/>.
+        /// </summary>
+        internal const string BleControlView = @"blecontrolview";
+
+        #endregion
+
+        #endregion
+    }
+}

--- a/src/BLEarringController/Views/NavigationQueryKeys.cs
+++ b/src/BLEarringController/Views/NavigationQueryKeys.cs
@@ -1,0 +1,20 @@
+﻿using Plugin.BLE.Abstractions.Contracts;
+
+namespace BLEarringController.Views
+{
+    internal static class NavigationQueryKeys
+    {
+        #region Constants
+
+        #region Internal
+
+        /// <summary>
+        /// The <see cref="IDevice"/> that was selected by the user.
+        /// </summary>
+        internal const string SelectedBleDeviceKey = @"selectedbledevice";
+
+        #endregion
+
+        #endregion
+    }
+}


### PR DESCRIPTION
In order to support this new view, the following changes have been made:

- `BleScanView` is now a modal.
- `BleScanView` now navigates back, returning the selected device when a scan result item is clicked.
- A new relative navigation route has been added to allow the modal to be called from the `BleControlView`.
- The `FixedAspectCard` custom control has been implemented.
- `BleConstants` and `NoridicUart` classes have been added to define the behaviour of the service used by the BLEarrings.
- New `IValueConverter`s have been added to create a contrasting colour for text over a background.
- Added `IQueryAttributable` to `ViewModelBase` to provide a virtual method that can be overriden to accept navigation arguments.
- Added classes to store the strings for views, modals, and query attributes.